### PR TITLE
add support modify conditions.

### DIFF
--- a/manifests/filter/modify.pp
+++ b/manifests/filter/modify.pp
@@ -24,6 +24,26 @@
 # @param hard_copy
 #  Copy a key/value pair with key KEY to COPIED_KEY if KEY exists.
 #  If COPIED_KEY already exists, this field is overwritten
+# @param key_exists
+#   Is true if KEY exists
+# @param key_does_not_exist
+#   Is true if KEY does not exist
+# @param a_key_matches
+#   Is true if a key matches regex KEY
+# @param no_key_matches
+#   Is true if no key matches regex KEY
+# @param key_value_equals
+#   Is true if KEY exists and its value is VALUE
+# @param key_value_does_not_equal
+#   Is true if KEY exists and its value is not VALUE
+# @param key_value_matches
+#   Is true if key KEY exists and its value matches VALUE
+# @param key_value_does_not_match
+#   Is true if key KEY exists and its value does not match VALUE
+# @param matching_keys_have_matching_values
+#   Is true if all keys matching KEY have values that match VALUE
+# @param matching_keys_do_not_have_matching_values
+#   Is true if all keys matching KEY have values that do not match VALUE
 # @example
 #   fluentbit::filter::modify { 'namevar': }
 define fluentbit::filter::modify (
@@ -38,6 +58,16 @@ define fluentbit::filter::modify (
   Optional $hard_rename      = undef,
   Optional $copy             = undef,
   Optional $hard_copy        = undef,
+  Array[String[1]] $key_exists                                          = [],
+  Array[String[1]] $key_does_not_exist                                  = [],
+  Array[String[1]] $a_key_matches                                       = [],
+  Array[String[1]] $no_key_matches                                      = [],
+  Hash[String[1], String[1]] $key_value_equals                          = {},
+  Hash[String[1], String[1]] $key_value_does_not_equal                  = {},
+  Hash[String[1], String[1]] $key_value_matches                         = {},
+  Hash[String[1], String[1]] $key_value_does_not_match                  = {},
+  Hash[String[1], String[1]] $matching_keys_have_matching_values        = {},
+  Hash[String[1], String[1]] $matching_keys_do_not_have_matching_values = {},
 ) {
   # create filter_modify.conf
   # TODO: concat for multiple entries

--- a/spec/defines/filter/modify_spec.rb
+++ b/spec/defines/filter/modify_spec.rb
@@ -1,16 +1,202 @@
 require 'spec_helper'
 
 describe 'fluentbit::filter::modify' do
-  let(:title) { 'namevar' }
-  let(:params) do
-    {}
+  let(:title) { 'rspec' }
+  let(:pre_condition) do
+    <<-MANIFEST
+class { 'fluentbit':
+  manage_package_repo => false,
+}
+MANIFEST
   end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:params) { {} }
 
-      it { is_expected.to compile }
+      context 'with default parameters' do
+        let(:params) do
+          super().merge({})
+        end
+        let(:rendered) do
+          <<EOF
+# Managed by puppet
+[FILTER]
+    Name                                                modify
+    Match                                               *
+EOF
+        end
+
+        it do
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/filter_modify_rspec.conf')
+            .with_content(rendered)
+        end
+      end
+
+      context 'with rule parameters' do
+        let(:params) do
+          super().merge({
+            remove: [ 'remove', 'delete' ],
+            remove_wildcard: [ 'wild*', 'card*' ],
+            remove_regex: [ 'regex.+', 'pattern.*' ],
+            set: {
+              set: 'this',
+              test: 'rspec',
+            },
+            add: {
+              key: 'value',
+              rule: 'test',
+            },
+            rename: {
+              old: 'new',
+              this: 'that',
+            },
+            hard_rename: {
+              force_old: 'force_new',
+              force_this: 'force_that',
+            },
+            copy: {
+              source: 'target',
+              origin: 'destination',
+            },
+            hard_copy: {
+              force_source: 'force_target',
+              force_origin: 'force_destination',
+            },
+          })
+        end
+        let(:rendered) do
+          <<EOF
+# Managed by puppet
+[FILTER]
+    Name                                                modify
+    Match                                               *
+    Set                                                 set this
+    Set                                                 test rspec
+    Add                                                 key value
+    Add                                                 rule test
+    Remove                                              remove
+    Remove                                              delete
+    Remove_wildcard                                     wild*
+    Remove_wildcard                                     card*
+    Remove_regex                                        regex.+
+    Remove_regex                                        pattern.*
+    Rename                                              old new
+    Rename                                              this that
+    Hard_rename                                         force_old force_new
+    Hard_rename                                         force_this force_that
+    Copy                                                source target
+    Copy                                                origin destination
+    Hard_copy                                           force_source force_target
+    Hard_copy                                           force_origin force_destination
+EOF
+        end
+
+        it do
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/filter_modify_rspec.conf')
+            .with_content(rendered)
+        end
+      end
+
+      context 'with rule parameters' do
+        let(:params) do
+          super().merge({
+            key_exists: ['exist', 'present'],
+            key_does_not_exist: ['not_exist', 'absent'],
+            a_key_matches: ['regex.*', 'pattern.*'],
+            no_key_matches: ['no_.+', 'missing_.+'],
+            key_value_equals: {
+              key_value_equals: 'check',
+              check_key_value_equals: 'true',
+            },
+            key_value_does_not_equal: {
+              key_value_does_not_equal: 'check',
+              check_key_value_does_not_equal: 'true',
+            },
+            key_value_matches: {
+              key_value_matches: 'check',
+              check_key_value_matches: 'true',
+            },
+            key_value_does_not_match: {
+              key_value_does_not_match: 'check',
+              check_key_value_does_not_match: 'true',
+            },
+            matching_keys_have_matching_values: {
+              matching_keys_have_matching_values: 'check',
+              check_matching_keys_have_matching_values: 'true',
+            },
+            matching_keys_do_not_have_matching_values: {
+              matching_keys_do_not_have_matching_values: 'check',
+              check_matching_keys_do_not_have_matching_values: 'true',
+            },
+
+            set: {
+              'this_plugin_is_on': '🔥',
+            },
+          })
+        end
+        let(:rendered) do
+          <<EOF
+# Managed by puppet
+[FILTER]
+    Name                                                modify
+    Match                                               *
+    Condition Key_exists                                exist
+    Condition Key_exists                                present
+    Condition Key_does_not_exist                        not_exist
+    Condition Key_does_not_exist                        absent
+    Condition A_key_matches                             regex.*
+    Condition A_key_matches                             pattern.*
+    Condition No_key_matches                            no_.+
+    Condition No_key_matches                            missing_.+
+    Condition Key_value_equals                          key_value_equals check
+    Condition Key_value_equals                          check_key_value_equals true
+    Condition Key_value_does_not_equal                  key_value_does_not_equal check
+    Condition Key_value_does_not_equal                  check_key_value_does_not_equal true
+    Condition Key_value_matches                         key_value_matches check
+    Condition Key_value_matches                         check_key_value_matches true
+    Condition Key_value_does_not_match                  key_value_does_not_match check
+    Condition Key_value_does_not_match                  check_key_value_does_not_match true
+    Condition Matching_keys_have_matching_values        matching_keys_have_matching_values check
+    Condition Matching_keys_have_matching_values        check_matching_keys_have_matching_values true
+    Condition Matching_keys_do_not_have_matching_values matching_keys_do_not_have_matching_values check
+    Condition Matching_keys_do_not_have_matching_values check_matching_keys_do_not_have_matching_values true
+    Set                                                 this_plugin_is_on 🔥
+EOF
+        end
+
+        it do
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/filter_modify_rspec.conf')
+            .with_content(rendered)
+        end
+      end
+
+      context 'with single value parameters' do
+        let(:params) do
+          super().merge({
+            remove: 'key',
+            remove_wildcard: 'wildcard*',
+            remove_regex: 'regex.*',
+          })
+        end
+        let(:rendered) do
+          <<EOF
+# Managed by puppet
+[FILTER]
+    Name                                                modify
+    Match                                               *
+    Remove                                              key
+    Remove_wildcard                                     wildcard*
+    Remove_regex                                        regex.*
+EOF
+        end
+
+        it do
+          is_expected.to contain_file('/etc/td-agent-bit/plugins.d/filter_modify_rspec.conf')
+            .with_content(rendered)
+        end
+      end
     end
   end
 end

--- a/templates/filter/modify.conf.erb
+++ b/templates/filter/modify.conf.erb
@@ -1,48 +1,63 @@
 # Managed by puppet
-# Filter to modify output
 [FILTER]
-    # configure plugins
-    Name  modify<%- if @match %>
-    Match <%= @match -%>
+    Name                                                modify
+<% if @match -%>
+    Match                                               <%= @match %>
 <% end -%>
-<% if @set %>
-<% @set.each do |key, value| %>
-    Set <%= key %> <%= value -%>
+<% @key_exists.each do |key| -%>
+    Condition Key_exists                                <%= key %>
 <% end -%>
+<% @key_does_not_exist.each do |key| -%>
+    Condition Key_does_not_exist                        <%= key %>
 <% end -%>
-<% if @add -%>
-<%- @add.each do |key, value| %>
-    Add <%= key %> <%= value -%>
+<% @a_key_matches.each do |key| -%>
+    Condition A_key_matches                             <%= key %>
 <% end -%>
+<% @no_key_matches.each do |key| -%>
+    Condition No_key_matches                            <%= key %>
 <% end -%>
-<% if @remove -%>
-<%- @remove.each do |key, value| %>
-    Remove <%= key %> <%= value -%>
+<% @key_value_equals.each do |key, value| -%>
+    Condition Key_value_equals                          <%= key %> <%= value %>
 <% end -%>
+<% @key_value_does_not_equal.each do |key, value| -%>
+    Condition Key_value_does_not_equal                  <%= key %> <%= value %>
 <% end -%>
-<%- if @remove_wildcard %>
-    Remove_wildcard <%= @remove_wildcard -%>
+<% @key_value_matches.each do |key, value| -%>
+    Condition Key_value_matches                         <%= key %> <%= value %>
 <% end -%>
-<%- if @remove_regex %>
-    Remove_regex <%= @remove_regex -%>
+<% @key_value_does_not_match.each do |key, value| -%>
+    Condition Key_value_does_not_match                  <%= key %> <%= value %>
 <% end -%>
-<% if @rename -%>
-<%- @rename.each do |key, value| %>
-    Rename <%= key %> <%= value -%>
+<% @matching_keys_have_matching_values.each do |key, value| -%>
+    Condition Matching_keys_have_matching_values        <%= key %> <%= value %>
 <% end -%>
+<% @matching_keys_do_not_have_matching_values.each do |key, value| -%>
+    Condition Matching_keys_do_not_have_matching_values <%= key %> <%= value %>
 <% end -%>
-<% if @hard_rename -%>
-<%- @hard_rename.each do |key, value| %>
-    Hard_rename <%= key %> <%= value -%>
+<% Hash(@set).each do |key, value| -%>
+    Set                                                 <%= key %> <%= value %>
 <% end -%>
+<% Hash(@add).each do |key, value| -%>
+    Add                                                 <%= key %> <%= value %>
 <% end -%>
-<% if @copy -%>
-<%- @copy.each do |key, value| %>
-    Copy <%= key %> <%= value -%>
+<% Array(@remove).each do |key| -%>
+    Remove                                              <%= key %>
 <% end -%>
+<% Array(@remove_wildcard).each do |key| -%>
+    Remove_wildcard                                     <%= key %>
 <% end -%>
-<% if @hard_copy -%>
-<%- @hard_copy.each do |key, value| %>
-    Hard_copy <%= key %> <%= value -%>
+<% Array(@remove_regex).each do |key| -%>
+    Remove_regex                                        <%= key %>
 <% end -%>
+<% Hash(@rename).each do |key, value| -%>
+    Rename                                              <%= key %> <%= value %>
+<% end -%>
+<% Hash(@hard_rename).each do |key, value| -%>
+    Hard_rename                                         <%= key %> <%= value %>
+<% end -%>
+<% Hash(@copy).each do |key, value| -%>
+    Copy                                                <%= key %> <%= value %>
+<% end -%>
+<% Hash(@hard_copy).each do |key, value| -%>
+    Hard_copy                                           <%= key %> <%= value %>
 <% end -%>


### PR DESCRIPTION
all of the conditional parameters of the modify plugin (tested with 1.3) are now also supported.

NOTE: this change is backwards compatible. the remove_wildcard and remove_regex parameters also support arrays now. single values continue to work as before.

this change depends on #1 being merged first